### PR TITLE
Implement GetEventsSince endpoint and improve error messages

### DIFF
--- a/pkg/httphandler/controller/event_controller.go
+++ b/pkg/httphandler/controller/event_controller.go
@@ -71,8 +71,7 @@ func (ctrl *EventController) AddEventToAggregate(c *gin.Context) {
 func (ctrl *EventController) GetEventsSince(c *gin.Context) {
 	eventId := c.Param("eventId")
 	if len(strings.TrimSpace(eventId)) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Path param cant be empty or null"})
-		return
+		eventId = "0"
 	}
 	limitStr := c.Query("limit")
 	limit := 100

--- a/pkg/store/event_repository_test.go
+++ b/pkg/store/event_repository_test.go
@@ -295,12 +295,12 @@ func TestGetEventsSinceEvent(t *testing.T) {
 
 	events, err := repo.GetEventsSinceEvent(event1.Id, 2)
 	assert.NoError(t, err)
-	assert.Len(t, events, 4)
+	assert.Len(t, events, 2)
 	assert.Equal(t, event1.Name, events[0].Name)
 	assert.Equal(t, event2.Name, events[1].Name)
 	events, err = repo.GetEventsSinceEvent(events[1].Id, 2)
 	assert.NoError(t, err)
-	assert.Len(t, events, 4)
+	assert.Len(t, events, 2)
 	assert.Equal(t, event3.Name, events[0].Name)
 	assert.Equal(t, event4.Name, events[1].Name)
 }


### PR DESCRIPTION
This pull request includes multiple changes to improve error messages, add new functionality, and enhance testing in the `pkg` directory. The most important changes are the standardization of error messages, the addition of a new method to retrieve events since a given event ID, and updates to integration tests.

### Error Message Standardization:
* [`pkg/client/http_client.go`](diffhunk://#diff-6f517f48ce738c7f588eec4ebf2a57bdf966c49cbca6537fffb6c88adb52a985L57-R67): Standardized error messages to use lowercase formatting for consistency. [[1]](diffhunk://#diff-6f517f48ce738c7f588eec4ebf2a57bdf966c49cbca6537fffb6c88adb52a985L57-R67) [[2]](diffhunk://#diff-6f517f48ce738c7f588eec4ebf2a57bdf966c49cbca6537fffb6c88adb52a985L78-R96) [[3]](diffhunk://#diff-6f517f48ce738c7f588eec4ebf2a57bdf966c49cbca6537fffb6c88adb52a985L105-R127)
* [`pkg/integration_test/integration_test.go`](diffhunk://#diff-e91e2947170c18ca41c2e8de41611bc2e04ff10cdbdd52681f4ed3a3a7f1c38aL22-R23): Updated error messages in integration tests to use lowercase formatting. [[1]](diffhunk://#diff-e91e2947170c18ca41c2e8de41611bc2e04ff10cdbdd52681f4ed3a3a7f1c38aL22-R23) [[2]](diffhunk://#diff-e91e2947170c18ca41c2e8de41611bc2e04ff10cdbdd52681f4ed3a3a7f1c38aL54-R125)

### New Functionality:
* [`pkg/client/http_client.go`](diffhunk://#diff-6f517f48ce738c7f588eec4ebf2a57bdf966c49cbca6537fffb6c88adb52a985R144-R189): Added `GetEventsSince` method to retrieve events since a specified event ID with a limit on the number of events.
* [`pkg/httphandler/controller/event_controller.go`](diffhunk://#diff-6aee0fe5dd05c7106957537bff9e0c0775527b968d7ef0c1680c98acd8f165f9L74-R74): Modified `GetEventsSince` method to handle empty or null path parameters by setting a default event ID of "0".

### Testing Enhancements:
* [`pkg/integration_test/integration_test.go`](diffhunk://#diff-e91e2947170c18ca41c2e8de41611bc2e04ff10cdbdd52681f4ed3a3a7f1c38aR14): Added `github.com/stretchr/testify/assert` for improved test assertions.
* [`pkg/integration_test/integration_test.go`](diffhunk://#diff-e91e2947170c18ca41c2e8de41611bc2e04ff10cdbdd52681f4ed3a3a7f1c38aL54-R125): Added `TestClientGetEventsSince` to test the new `GetEventsSince` method.
* [`pkg/store/event_repository_test.go`](diffhunk://#diff-1bb3fa1cd48e39eae5d3cf48a88c8c63bd6723e58e87cb182c3b95fc83da3c9aL298-R303): Corrected the expected length of events in `TestGetEventsSinceEvent` to match the new functionality.